### PR TITLE
Include ID on profile info page

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,10 @@
         <td><%= _.escape(name) %></td>
       </tr>
       <tr>
+        <th>Profile ID</th>
+        <td><%= _.escape(id) %></td>
+      </tr>
+      <tr>
         <th>Vendor</th>
         <td><a href="#vendors/<%= _.escape(vendor_name_to_id(vendor)) %>"><%= _.escape(vendor) %></a></td>
       </tr>


### PR DESCRIPTION
As described in title. The profile ID was previously only visible in the URL.

![image](https://user-images.githubusercontent.com/2080552/47313896-6a089b00-d640-11e8-9fa1-d68f1d3b9c71.png)


